### PR TITLE
Add cmake compile scripts for perlmutter (nersc)

### DIFF
--- a/c/build/cmake_perlmutter_gnu_cpu.sh
+++ b/c/build/cmake_perlmutter_gnu_cpu.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source ${MODULESHOME}/init/bash
+module purge
+module load PrgEnv-gnu gcc/11.2.0 cray-mpich cray-parallel-netcdf cmake
+
+export TEST_MPI_COMMAND="srun -n 1"
+
+./cmake_clean.sh
+
+cmake -DCMAKE_CXX_COMPILER=mpic++                                                     \
+      -DCXXFLAGS="-Ofast -march=native -DNO_INFORM -std=c++11 -I${PNETCDF_DIR}/include"   \
+      -DLDFLAGS="-L${PNETCDF_DIR}/lib -lpnetcdf"                        \
+      -DOPENMP_FLAGS="-fopenmp"                                                       \
+      -DNX=200                                      \
+      -DNZ=100                                      \
+      -DSIM_TIME=1000                               \
+      -DOUT_FREQ=2000                     \
+      ..

--- a/cpp/build/cmake_perlmutter_gnu_cpu.sh
+++ b/cpp/build/cmake_perlmutter_gnu_cpu.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source ${MODULESHOME}/init/bash
+module purge
+module load PrgEnv-gnu gcc/11.2.0 cray-mpich cray-parallel-netcdf cmake
+
+export TEST_MPI_COMMAND="srun -n 1"
+unset CUDAFLAGS
+unset CXXFLAGS
+
+./cmake_clean.sh
+
+cmake -DCMAKE_CXX_COMPILER=mpic++                   \
+      -DCMAKE_C_COMPILER=mpicc                      \
+      -DCMAKE_Fortran_COMPILER=mpif90               \
+      -DYAKL_ARCH=""                                \
+      -DCXXFLAGS="-I${PNETCDF_DIR}/include -L${PNETCDF_DIR}/lib -lpnetcdf" \
+      -DYAKL_CUDA_FLAGS="-DHAVE_MPI -O3 --use_fast_math -arch sm_70 -ccbin mpic++ -I${PNETCDF_DIR}/include" \
+      -DLDFLAGS="-L${PNETCDF_DIR}/lib -lpnetcdf"  \
+      -DNX=200                                      \
+      -DNZ=100                                      \
+      -DSIM_TIME=1000                               \
+      -DOUT_FREQ=2000                     \
+      ..
+

--- a/cpp/build/cmake_perlmutter_gnu_gpu.sh
+++ b/cpp/build/cmake_perlmutter_gnu_gpu.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source ${MODULESHOME}/init/bash
+module purge
+module load PrgEnv-gnu gcc/11.2.0 cray-mpich cray-parallel-netcdf cmake cudatoolkit
+
+export TEST_MPI_COMMAND="srun -n 1 -c 1 -a 1 -g 1"
+
+#unset CUDAFLAGS
+#unset CXXFLAGS
+
+./cmake_clean.sh
+
+cmake -DCMAKE_CXX_COMPILER=mpic++                   \
+      -DCMAKE_C_COMPILER=mpicc                      \
+      -DCMAKE_Fortran_COMPILER=mpif90               \
+      -DYAKL_CUDA_FLAGS="-DHAVE_MPI -O3 --use_fast_math -arch sm_70 -ccbin mpic++ -I${PNETCDF_DIR}/include" \
+      -DLDFLAGS="-L${PNETCDF_DIR}/lib -lpnetcdf"  \
+      -DCXXFLAGS="-I${PNETCDF_DIR}/include -L${PNETCDF_DIR}/lib -lpnetcdf" \
+      -DNX=200                                      \
+      -DNZ=100                                      \
+      -DSIM_TIME=1000                               \
+      -DOUT_FREQ=2000                     \
+      -DYAKL_ARCH="CUDA"                                \
+      ..
+

--- a/fortran/build/cmake_perlmutter_gnu_cpu.sh
+++ b/fortran/build/cmake_perlmutter_gnu_cpu.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source ${MODULESHOME}/init/bash
+module load PrgEnv-gnu cray-mpich cray-parallel-netcdf cmake
+
+export TEST_MPI_COMMAND="srun -n 1"
+
+./cmake_clean.sh
+
+cmake -DCMAKE_Fortran_COMPILER=mpif90                                                 \
+      -DFFLAGS="-Ofast -march=native -ffree-line-length-none -DNO_INFORM -I${PNETCDF_DIR}/include"   \
+      -DLDFLAGS="-L${PNETCDF_DIR}/lib -lpnetcdf"                        \
+      -DOPENMP_FLAGS="-fopenmp"                                                       \
+      -DNX=200                                      \
+      -DNZ=100                                      \
+      -DSIM_TIME=1000                               \
+      -DOUT_FREQ=2000                     \
+      ..


### PR DESCRIPTION
Adding perlmutter scripts for:
- c/build/cmake_perlmutter_gnu_cpu.sh
- cpp/build/cmake_perlmutter_gnu_cpu.sh
- cpp/build/cmake_perlmutter_gnu_gpu.sh
- fortran/build/cmake_perlmutter_gnu_cpu.sh

Note, perlmutter includes NVIDIA A100 GPUs, so I chose `-DYAKL_ARCH="CUDA"` for the cpp gpu version.