### PR TITLE
Update cpp perlmutter compile script for gpus

### DIFF
--- a/cpp/build/cmake_perlmutter_gnu_gpu.sh
+++ b/cpp/build/cmake_perlmutter_gnu_gpu.sh
@@ -2,7 +2,7 @@
 
 source ${MODULESHOME}/init/bash
 module purge
-module load PrgEnv-gnu gcc/11.2.0 cray-mpich cray-parallel-netcdf cmake cudatoolkit
+module load PrgEnv-nvidia cray-mpich cray-parallel-netcdf cmake cudatoolkit
 
 export TEST_MPI_COMMAND="srun -n 1 -c 1 -a 1 -g 1"
 
@@ -11,9 +11,9 @@ export TEST_MPI_COMMAND="srun -n 1 -c 1 -a 1 -g 1"
 
 ./cmake_clean.sh
 
-cmake -DCMAKE_CXX_COMPILER=mpic++                   \
+cmake -DCMAKE_CXX_COMPILER=CC                       \
       -DCMAKE_C_COMPILER=mpicc                      \
-      -DCMAKE_Fortran_COMPILER=mpif90               \
+      -DYAKL_ARCH="CUDA"                            \
       -DYAKL_CUDA_FLAGS="-DHAVE_MPI -O3 --use_fast_math -arch sm_70 -ccbin mpic++ -I${PNETCDF_DIR}/include" \
       -DLDFLAGS="-L${PNETCDF_DIR}/lib -lpnetcdf"  \
       -DCXXFLAGS="-I${PNETCDF_DIR}/include -L${PNETCDF_DIR}/lib -lpnetcdf" \
@@ -21,6 +21,5 @@ cmake -DCMAKE_CXX_COMPILER=mpic++                   \
       -DNZ=100                                      \
       -DSIM_TIME=1000                               \
       -DOUT_FREQ=2000                     \
-      -DYAKL_ARCH="CUDA"                                \
       ..
 


### PR DESCRIPTION
In order to compile for `YAKL_ARCH="CUDA"` on perlmutter, we need `module load PrgEnv-nvidia` and need to use c++ wrapper `MAKE_CXX_COMPILER=CC`.