### PR TITLE
move declarations to innermost scope, add const where possible

### DIFF
--- a/c/miniWeather_mpi_openmp45.cpp
+++ b/c/miniWeather_mpi_openmp45.cpp
@@ -224,8 +224,6 @@ void perform_timestep( double *state , double *state_tmp , double *flux , double
 //state_out = state_init + dt * rhs(state_forcing)
 //Meaning the step starts from state_init, computes the rhs using state_forcing, and stores the result in state_out
 void semi_discrete_step( double *state_init , double *state_forcing , double *state_out , double dt , int dir , double *flux , double *tend ) {
-  //int i, k, ll, inds, indt, indw;
-  //double x, z, wpert, dist, x0, z0, xrad, zrad, amp;
   if        (dir == DIR_X) {
     //Set the halo values for this MPI task's fluid state in the x-direction
     set_halo_values_x(state_forcing);
@@ -282,9 +280,7 @@ void semi_discrete_step( double *state_init , double *state_forcing , double *st
 //First, compute the flux vector at each cell interface in the x-direction (including hyperviscosity)
 //Then, compute the tendencies using those fluxes
 void compute_tendencies_x( double *state , double *flux , double *tend , double dt ) {
-  //int    i,k,ll,s,inds,indf1,indf2,indt;
-  //double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
-  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS]; //, hv_coef;
+  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS];
   //Compute the hyperviscosity coefficient
   const double hv_coef = -hv_beta * dx / (16*dt);
   //Compute fluxes in the x-direction for each cell
@@ -338,9 +334,7 @@ void compute_tendencies_x( double *state , double *flux , double *tend , double 
 //First, compute the flux vector at each cell interface in the z-direction (including hyperviscosity)
 //Then, compute the tendencies using those fluxes
 void compute_tendencies_z( double *state , double *flux , double *tend , double dt ) {
-  //int    i,k,ll,s, inds, indf1, indf2, indt;
-  //double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
-  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS];//, hv_coef;
+  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS];
   //Compute the hyperviscosity coefficient
   const double hv_coef = -hv_beta * dz / (16*dt);
   //Compute fluxes in the x-direction for each cell
@@ -400,9 +394,7 @@ void compute_tendencies_z( double *state , double *flux , double *tend , double 
 
 //Set this MPI task's halo values in the x-direction. This routine will require MPI
 void set_halo_values_x( double *state ) {
-  //int k, ll, ind_r, ind_u, ind_t, i, s, ierr;
   int ierr;
-  //double z;
   MPI_Request req_r[2], req_s[2];
 
   //Prepost receives
@@ -494,10 +486,6 @@ void set_halo_values_z( double *state ) {
 
 
 void init( int *argc , char ***argv ) {
-  //int    i, k, ii, kk, ll, ierr, inds, i_end;
-  //double x, z, r, u, w, t, hr, ht, nper;
-  //double z, r, u, w, t, hr, ht, nper;
-
   int ierr = MPI_Init(argc,argv);
 
   ierr = MPI_Comm_size(MPI_COMM_WORLD,&nranks);
@@ -701,7 +689,6 @@ void collision( double x , double z , double &r , double &u , double &w , double
 void hydro_const_theta( double z , double &r , double &t ) {
   const double theta0 = 300.;  //Background potential temperature
   const double exner0 = 1.;    //Surface-level Exner pressure
-  //double       p,exner,rt;
   //Establish hydrostatic balance first using Exner pressure
   t = theta0;                                  //Potential Temperature at z
   const double exner = exner0 - grav * z / (cp * theta0);   //Exner pressure at z
@@ -718,7 +705,6 @@ void hydro_const_theta( double z , double &r , double &t ) {
 void hydro_const_bvfreq( double z , double bv_freq0 , double &r , double &t ) {
   const double theta0 = 300.;  //Background potential temperature
   const double exner0 = 1.;    //Surface-level Exner pressure
-  //double       p, exner, rt;
   t = theta0 * exp( bv_freq0*bv_freq0 / grav * z );                                    //Pot temp at z
   const double exner = exner0 - grav*grav / (cp * bv_freq0*bv_freq0) * (t - theta0) / (t * theta0); //Exner pressure at z
   const double p = p0 * pow(exner,(cp/rd));                                                         //Pressure at z
@@ -748,7 +734,6 @@ double sample_ellipse_cosine( double x , double z , double amp , double x0 , dou
 //If it's too cumbersome, you can comment the I/O out, but you'll miss out on some potentially cool graphics
 void output( double *state , double etime ) {
   int ncid, t_dimid, x_dimid, z_dimid, dens_varid, uwnd_varid, wwnd_varid, theta_varid, t_varid, dimids[3];
-  //int i, k, ind_r, ind_u, ind_w, ind_t;
   MPI_Offset st1[1], ct1[1], st3[3], ct3[3];
   //Temporary arrays to hold density, u-wind, w-wind, and potential temperature (theta)
   double *dens, *uwnd, *wwnd, *theta;

--- a/c/miniWeather_mpi_openmp45.cpp
+++ b/c/miniWeather_mpi_openmp45.cpp
@@ -224,8 +224,8 @@ void perform_timestep( double *state , double *state_tmp , double *flux , double
 //state_out = state_init + dt * rhs(state_forcing)
 //Meaning the step starts from state_init, computes the rhs using state_forcing, and stores the result in state_out
 void semi_discrete_step( double *state_init , double *state_forcing , double *state_out , double dt , int dir , double *flux , double *tend ) {
-  int i, k, ll, inds, indt, indw;
-  double x, z, wpert, dist, x0, z0, xrad, zrad, amp;
+  //int i, k, ll, inds, indt, indw;
+  //double x, z, wpert, dist, x0, z0, xrad, zrad, amp;
   if        (dir == DIR_X) {
     //Set the halo values for this MPI task's fluid state in the x-direction
     set_halo_values_x(state_forcing);
@@ -240,23 +240,24 @@ void semi_discrete_step( double *state_init , double *state_forcing , double *st
 
   //Apply the tendencies to the fluid state
 #pragma omp target teams distribute parallel for simd collapse(3) depend(inout:asyncid) nowait
-  for (ll=0; ll<NUM_VARS; ll++) {
-    for (k=0; k<nz; k++) {
-      for (i=0; i<nx; i++) {
+  for (int ll=0; ll<NUM_VARS; ll++) {
+    for (int k=0; k<nz; k++) {
+      for (int i=0; i<nx; i++) {
         if (data_spec_int == DATA_SPEC_GRAVITY_WAVES) {
-          x = (i_beg + i+0.5)*dx;
-          z = (k_beg + k+0.5)*dz;
+          const double x = (i_beg + i+0.5)*dx;
+          const double z = (k_beg + k+0.5)*dz;
+          double wpert;
           // Using sample_ellipse_cosine requires "acc routine" in OpenACC and "declare target" in OpenMP offload
           // Neither of these are particularly well supported. So I'm manually inlining here
           // wpert = sample_ellipse_cosine( x,z , 0.01 , xlen/8,1000., 500.,500. );
           {
-            x0   = xlen/8;
-            z0   = 1000;
-            xrad = 500;
-            zrad = 500;
-            amp  = 0.01;
+            const double x0   = xlen/8;
+            const double z0   = 1000;
+            const double xrad = 500;
+            const double zrad = 500;
+            const double amp  = 0.01;
             //Compute distance from bubble center
-            dist = sqrt( ((x-x0)/xrad)*((x-x0)/xrad) + ((z-z0)/zrad)*((z-z0)/zrad) ) * pi / 2.;
+            const double dist = sqrt( ((x-x0)/xrad)*((x-x0)/xrad) + ((z-z0)/zrad)*((z-z0)/zrad) ) * pi / 2.;
             //If the distance from bubble center is less than the radius, create a cos**2 profile
             if (dist <= pi / 2.) {
               wpert = amp * pow(cos(dist),2.);
@@ -264,11 +265,11 @@ void semi_discrete_step( double *state_init , double *state_forcing , double *st
               wpert = 0.;
             }
           }
-          indw = ID_WMOM*nz*nx + k*nx + i;
+          const int indw = ID_WMOM*nz*nx + k*nx + i;
           tend[indw] += wpert*hy_dens_cell[hs+k];
         }
-        inds = ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-        indt = ll*nz*nx + k*nx + i;
+        const int inds = ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+        const int indt = ll*nz*nx + k*nx + i;
         state_out[inds] = state_init[inds] + dt * tend[indt];
       }
     }
@@ -281,18 +282,19 @@ void semi_discrete_step( double *state_init , double *state_forcing , double *st
 //First, compute the flux vector at each cell interface in the x-direction (including hyperviscosity)
 //Then, compute the tendencies using those fluxes
 void compute_tendencies_x( double *state , double *flux , double *tend , double dt ) {
-  int    i,k,ll,s,inds,indf1,indf2,indt;
-  double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
+  //int    i,k,ll,s,inds,indf1,indf2,indt;
+  //double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
+  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
   //Compute the hyperviscosity coefficient
   hv_coef = -hv_beta * dx / (16*dt);
   //Compute fluxes in the x-direction for each cell
 #pragma omp target teams distribute parallel for simd collapse(2) private(stencil,vals,d3_vals) depend(inout:asyncid) nowait
-  for (k=0; k<nz; k++) {
-    for (i=0; i<nx+1; i++) {
+  for (int k=0; k<nz; k++) {
+    for (int i=0; i<nx+1; i++) {
       //Use fourth-order interpolation from four cell averages to compute the value at the interface in question
-      for (ll=0; ll<NUM_VARS; ll++) {
-        for (s=0; s < sten_size; s++) {
-          inds = ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+s;
+      for (int ll=0; ll<NUM_VARS; ll++) {
+        for (int s=0; s < sten_size; s++) {
+          const int inds = ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+s;
           stencil[s] = state[inds];
         }
         //Fourth-order-accurate interpolation of the state
@@ -302,11 +304,11 @@ void compute_tendencies_x( double *state , double *flux , double *tend , double 
       }
 
       //Compute density, u-wind, w-wind, potential temperature, and pressure (r,u,w,t,p respectively)
-      r = vals[ID_DENS] + hy_dens_cell[k+hs];
-      u = vals[ID_UMOM] / r;
-      w = vals[ID_WMOM] / r;
-      t = ( vals[ID_RHOT] + hy_dens_theta_cell[k+hs] ) / r;
-      p = C0*pow((r*t),gamm);
+      const double r = vals[ID_DENS] + hy_dens_cell[k+hs];
+      const double u = vals[ID_UMOM] / r;
+      const double w = vals[ID_WMOM] / r;
+      const double t = ( vals[ID_RHOT] + hy_dens_theta_cell[k+hs] ) / r;
+      const double p = C0*pow((r*t),gamm);
 
       //Compute the flux vector
       flux[ID_DENS*(nz+1)*(nx+1) + k*(nx+1) + i] = r*u     - hv_coef*d3_vals[ID_DENS];
@@ -318,12 +320,12 @@ void compute_tendencies_x( double *state , double *flux , double *tend , double 
 
   //Use the fluxes to compute tendencies for each cell
 #pragma omp target teams distribute parallel for simd collapse(3) depend(inout:asyncid) nowait
-  for (ll=0; ll<NUM_VARS; ll++) {
-    for (k=0; k<nz; k++) {
-      for (i=0; i<nx; i++) {
-        indt  = ll* nz   * nx    + k* nx    + i  ;
-        indf1 = ll*(nz+1)*(nx+1) + k*(nx+1) + i  ;
-        indf2 = ll*(nz+1)*(nx+1) + k*(nx+1) + i+1;
+  for (int ll=0; ll<NUM_VARS; ll++) {
+    for (int k=0; k<nz; k++) {
+      for (int i=0; i<nx; i++) {
+        const int indt  = ll* nz   * nx    + k* nx    + i  ;
+        const int indf1 = ll*(nz+1)*(nx+1) + k*(nx+1) + i  ;
+        const int indf2 = ll*(nz+1)*(nx+1) + k*(nx+1) + i+1;
         tend[indt] = -( flux[indf2] - flux[indf1] ) / dx;
       }
     }
@@ -336,18 +338,19 @@ void compute_tendencies_x( double *state , double *flux , double *tend , double 
 //First, compute the flux vector at each cell interface in the z-direction (including hyperviscosity)
 //Then, compute the tendencies using those fluxes
 void compute_tendencies_z( double *state , double *flux , double *tend , double dt ) {
-  int    i,k,ll,s, inds, indf1, indf2, indt;
-  double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
+  //int    i,k,ll,s, inds, indf1, indf2, indt;
+  //double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
+  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
   //Compute the hyperviscosity coefficient
   hv_coef = -hv_beta * dz / (16*dt);
   //Compute fluxes in the x-direction for each cell
 #pragma omp target teams distribute parallel for simd collapse(2) private(stencil,vals,d3_vals) depend(inout:asyncid) nowait
-  for (k=0; k<nz+1; k++) {
-    for (i=0; i<nx; i++) {
+  for (int k=0; k<nz+1; k++) {
+    for (int i=0; i<nx; i++) {
       //Use fourth-order interpolation from four cell averages to compute the value at the interface in question
-      for (ll=0; ll<NUM_VARS; ll++) {
-        for (s=0; s<sten_size; s++) {
-          inds = ll*(nz+2*hs)*(nx+2*hs) + (k+s)*(nx+2*hs) + i+hs;
+      for (int ll=0; ll<NUM_VARS; ll++) {
+        for (int s=0; s<sten_size; s++) {
+          const int inds = ll*(nz+2*hs)*(nx+2*hs) + (k+s)*(nx+2*hs) + i+hs;
           stencil[s] = state[inds];
         }
         //Fourth-order-accurate interpolation of the state
@@ -357,11 +360,11 @@ void compute_tendencies_z( double *state , double *flux , double *tend , double 
       }
 
       //Compute density, u-wind, w-wind, potential temperature, and pressure (r,u,w,t,p respectively)
-      r = vals[ID_DENS] + hy_dens_int[k];
-      u = vals[ID_UMOM] / r;
-      w = vals[ID_WMOM] / r;
-      t = ( vals[ID_RHOT] + hy_dens_theta_int[k] ) / r;
-      p = C0*pow((r*t),gamm) - hy_pressure_int[k];
+      const double r = vals[ID_DENS] + hy_dens_int[k];
+      const double u = vals[ID_UMOM] / r;
+            double w = vals[ID_WMOM] / r;
+      const double t = ( vals[ID_RHOT] + hy_dens_theta_int[k] ) / r;
+      const double p = C0*pow((r*t),gamm) - hy_pressure_int[k];
       //Enforce vertical boundary condition and exact mass conservation
       if (k == 0 || k == nz) {
         w                = 0;
@@ -378,15 +381,15 @@ void compute_tendencies_z( double *state , double *flux , double *tend , double 
 
   //Use the fluxes to compute tendencies for each cell
 #pragma omp target teams distribute parallel for simd collapse(3) depend(inout:asyncid) nowait
-  for (ll=0; ll<NUM_VARS; ll++) {
-    for (k=0; k<nz; k++) {
-      for (i=0; i<nx; i++) {
-        indt  = ll* nz   * nx    + k* nx    + i  ;
-        indf1 = ll*(nz+1)*(nx+1) + (k  )*(nx+1) + i;
-        indf2 = ll*(nz+1)*(nx+1) + (k+1)*(nx+1) + i;
+  for (int ll=0; ll<NUM_VARS; ll++) {
+    for (int k=0; k<nz; k++) {
+      for (int i=0; i<nx; i++) {
+        const int indt  = ll* nz   * nx    + k* nx    + i  ;
+        const int indf1 = ll*(nz+1)*(nx+1) + (k  )*(nx+1) + i;
+        const int indf2 = ll*(nz+1)*(nx+1) + (k+1)*(nx+1) + i;
         tend[indt] = -( flux[indf2] - flux[indf1] ) / dz;
         if (ll == ID_WMOM) {
-          inds = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+          const int inds = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
           tend[indt] = tend[indt] - state[inds]*grav;
         }
       }
@@ -397,8 +400,9 @@ void compute_tendencies_z( double *state , double *flux , double *tend , double 
 
 //Set this MPI task's halo values in the x-direction. This routine will require MPI
 void set_halo_values_x( double *state ) {
-  int k, ll, ind_r, ind_u, ind_t, i, s, ierr;
-  double z;
+  //int k, ll, ind_r, ind_u, ind_t, i, s, ierr;
+  int ierr;
+  //double z;
   MPI_Request req_r[2], req_s[2];
 
   //Prepost receives
@@ -407,9 +411,9 @@ void set_halo_values_x( double *state ) {
 
   //Pack the send buffers
 #pragma omp target teams distribute parallel for simd collapse(3) depend(inout:asyncid) nowait
-  for (ll=0; ll<NUM_VARS; ll++) {
-    for (k=0; k<nz; k++) {
-      for (s=0; s<hs; s++) {
+  for (int ll=0; ll<NUM_VARS; ll++) {
+    for (int k=0; k<nz; k++) {
+      for (int s=0; s<hs; s++) {
         sendbuf_l[ll*nz*hs + k*hs + s] = state[ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + hs+s];
         sendbuf_r[ll*nz*hs + k*hs + s] = state[ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + nx+s];
       }
@@ -430,9 +434,9 @@ void set_halo_values_x( double *state ) {
 
   //Unpack the receive buffers
 #pragma omp target teams distribute parallel for simd collapse(3) depend(inout:asyncid) nowait
-  for (ll=0; ll<NUM_VARS; ll++) {
-    for (k=0; k<nz; k++) {
-      for (s=0; s<hs; s++) {
+  for (int ll=0; ll<NUM_VARS; ll++) {
+    for (int k=0; k<nz; k++) {
+      for (int s=0; s<hs; s++) {
         state[ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + s      ] = recvbuf_l[ll*nz*hs + k*hs + s];
         state[ll*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + nx+hs+s] = recvbuf_r[ll*nz*hs + k*hs + s];
       }
@@ -445,13 +449,13 @@ void set_halo_values_x( double *state ) {
   if (data_spec_int == DATA_SPEC_INJECTION) {
     if (myrank == 0) {
 #pragma omp target teams distribute parallel for simd collapse(2) depend(inout:asyncid) nowait
-      for (k=0; k<nz; k++) {
-        for (i=0; i<hs; i++) {
-          z = (k_beg + k+0.5)*dz;
+      for (int k=0; k<nz; k++) {
+        for (int i=0; i<hs; i++) {
+          const double z = (k_beg + k+0.5)*dz;
           if (fabs(z-3*zlen/4) <= zlen/16) {
-            ind_r = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i;
-            ind_u = ID_UMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i;
-            ind_t = ID_RHOT*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i;
+            const int ind_r = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i;
+            const int ind_u = ID_UMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i;
+            const int ind_t = ID_RHOT*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i;
             state[ind_u] = (state[ind_r]+hy_dens_cell[k+hs]) * 50.;
             state[ind_t] = (state[ind_r]+hy_dens_cell[k+hs]) * 298. - hy_dens_theta_cell[k+hs];
           }
@@ -465,10 +469,9 @@ void set_halo_values_x( double *state ) {
 //Set this MPI task's halo values in the z-direction. This does not require MPI because there is no MPI
 //decomposition in the vertical direction
 void set_halo_values_z( double *state ) {
-  int          i, ll;
 #pragma omp target teams distribute parallel for simd collapse(2) depend(inout:asyncid) nowait
-  for (ll=0; ll<NUM_VARS; ll++) {
-    for (i=0; i<nx+2*hs; i++) {
+  for (int ll=0; ll<NUM_VARS; ll++) {
+    for (int i=0; i<nx+2*hs; i++) {
       if (ll == ID_WMOM) {
         state[ll*(nz+2*hs)*(nx+2*hs) + (0      )*(nx+2*hs) + i] = 0.;
         state[ll*(nz+2*hs)*(nx+2*hs) + (1      )*(nx+2*hs) + i] = 0.;
@@ -491,16 +494,17 @@ void set_halo_values_z( double *state ) {
 
 
 void init( int *argc , char ***argv ) {
-  int    i, k, ii, kk, ll, ierr, inds, i_end;
-  double x, z, r, u, w, t, hr, ht, nper;
+  //int    i, k, ii, kk, ll, ierr, inds, i_end;
+  //double x, z, r, u, w, t, hr, ht, nper;
+  double z, r, u, w, t, hr, ht, nper;
 
-  ierr = MPI_Init(argc,argv);
+  int ierr = MPI_Init(argc,argv);
 
   ierr = MPI_Comm_size(MPI_COMM_WORLD,&nranks);
   ierr = MPI_Comm_rank(MPI_COMM_WORLD,&myrank);
   nper = ( (double) nx_glob ) / nranks;
-  i_beg = round( nper* (myrank)    );
-  i_end = round( nper*((myrank)+1) )-1;
+  const int i_beg = round( nper* (myrank)    );
+  const int i_end = round( nper*((myrank)+1) )-1;
   nx = i_end - i_beg + 1;
   left_rank  = myrank - 1;
   if (left_rank == -1) left_rank = nranks-1;
@@ -552,19 +556,19 @@ void init( int *argc , char ***argv ) {
   //////////////////////////////////////////////////////////////////////////
   // Initialize the cell-averaged fluid state via Gauss-Legendre quadrature
   //////////////////////////////////////////////////////////////////////////
-  for (k=0; k<nz+2*hs; k++) {
-    for (i=0; i<nx+2*hs; i++) {
+  for (int k=0; k<nz+2*hs; k++) {
+    for (int i=0; i<nx+2*hs; i++) {
       //Initialize the state to zero
-      for (ll=0; ll<NUM_VARS; ll++) {
-        inds = ll*(nz+2*hs)*(nx+2*hs) + k*(nx+2*hs) + i;
+      for (int ll=0; ll<NUM_VARS; ll++) {
+        const int inds = ll*(nz+2*hs)*(nx+2*hs) + k*(nx+2*hs) + i;
         state[inds] = 0.;
       }
       //Use Gauss-Legendre quadrature to initialize a hydrostatic balance + temperature perturbation
-      for (kk=0; kk<nqpoints; kk++) {
-        for (ii=0; ii<nqpoints; ii++) {
+      for (int kk=0; kk<nqpoints; kk++) {
+        for (int ii=0; ii<nqpoints; ii++) {
           //Compute the x,z location within the global domain based on cell and quadrature index
-          x = (i_beg + i-hs+0.5)*dx + (qpoints[ii]-0.5)*dx;
-          z = (k_beg + k-hs+0.5)*dz + (qpoints[kk]-0.5)*dz;
+          const double x = (i_beg + i-hs+0.5)*dx + (qpoints[ii]-0.5)*dx;
+          const double z = (k_beg + k-hs+0.5)*dz + (qpoints[kk]-0.5)*dz;
 
           //Set the fluid state based on the user's specification
           if (data_spec_int == DATA_SPEC_COLLISION      ) { collision      (x,z,r,u,w,t,hr,ht); }
@@ -574,7 +578,7 @@ void init( int *argc , char ***argv ) {
           if (data_spec_int == DATA_SPEC_INJECTION      ) { injection      (x,z,r,u,w,t,hr,ht); }
 
           //Store into the fluid state array
-          inds = ID_DENS*(nz+2*hs)*(nx+2*hs) + k*(nx+2*hs) + i;
+          int inds = ID_DENS*(nz+2*hs)*(nx+2*hs) + k*(nx+2*hs) + i;
           state[inds] = state[inds] + r                         * qweights[ii]*qweights[kk];
           inds = ID_UMOM*(nz+2*hs)*(nx+2*hs) + k*(nx+2*hs) + i;
           state[inds] = state[inds] + (r+hr)*u                  * qweights[ii]*qweights[kk];
@@ -584,18 +588,18 @@ void init( int *argc , char ***argv ) {
           state[inds] = state[inds] + ( (r+hr)*(t+ht) - hr*ht ) * qweights[ii]*qweights[kk];
         }
       }
-      for (ll=0; ll<NUM_VARS; ll++) {
-        inds = ll*(nz+2*hs)*(nx+2*hs) + k*(nx+2*hs) + i;
+      for (int ll=0; ll<NUM_VARS; ll++) {
+        const int inds = ll*(nz+2*hs)*(nx+2*hs) + k*(nx+2*hs) + i;
         state_tmp[inds] = state[inds];
       }
     }
   }
   //Compute the hydrostatic background state over vertical cell averages
-  for (k=0; k<nz+2*hs; k++) {
+  for (int k=0; k<nz+2*hs; k++) {
     hy_dens_cell      [k] = 0.;
     hy_dens_theta_cell[k] = 0.;
-    for (kk=0; kk<nqpoints; kk++) {
-      z = (k_beg + k-hs+0.5)*dz;
+    for (int kk=0; kk<nqpoints; kk++) {
+      const double z = (k_beg + k-hs+0.5)*dz;
       //Set the fluid state based on the user's specification
       if (data_spec_int == DATA_SPEC_COLLISION      ) { collision      (0.,z,r,u,w,t,hr,ht); }
       if (data_spec_int == DATA_SPEC_THERMAL        ) { thermal        (0.,z,r,u,w,t,hr,ht); }
@@ -607,7 +611,7 @@ void init( int *argc , char ***argv ) {
     }
   }
   //Compute the hydrostatic background state at vertical cell interfaces
-  for (k=0; k<nz+1; k++) {
+  for (int k=0; k<nz+1; k++) {
     z = (k_beg + k)*dz;
     if (data_spec_int == DATA_SPEC_COLLISION      ) { collision      (0.,z,r,u,w,t,hr,ht); }
     if (data_spec_int == DATA_SPEC_THERMAL        ) { thermal        (0.,z,r,u,w,t,hr,ht); }
@@ -742,7 +746,7 @@ double sample_ellipse_cosine( double x , double z , double amp , double x0 , dou
 //If it's too cumbersome, you can comment the I/O out, but you'll miss out on some potentially cool graphics
 void output( double *state , double etime ) {
   int ncid, t_dimid, x_dimid, z_dimid, dens_varid, uwnd_varid, wwnd_varid, theta_varid, t_varid, dimids[3];
-  int i, k, ind_r, ind_u, ind_w, ind_t;
+  //int i, k, ind_r, ind_u, ind_w, ind_t;
   MPI_Offset st1[1], ct1[1], st3[3], ct3[3];
   //Temporary arrays to hold density, u-wind, w-wind, and potential temperature (theta)
   double *dens, *uwnd, *wwnd, *theta;
@@ -790,12 +794,12 @@ void output( double *state , double etime ) {
   }
 
   //Store perturbed values in the temp arrays for output
-  for (k=0; k<nz; k++) {
-    for (i=0; i<nx; i++) {
-      ind_r = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-      ind_u = ID_UMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-      ind_w = ID_WMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-      ind_t = ID_RHOT*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+  for (int k=0; k<nz; k++) {
+    for (int i=0; i<nx; i++) {
+      const int ind_r = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+      const int ind_u = ID_UMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+      const int ind_w = ID_WMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+      const int ind_t = ID_RHOT*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
       dens [k*nx+i] = state[ind_r];
       uwnd [k*nx+i] = state[ind_u] / ( hy_dens_cell[k+hs] + state[ind_r] );
       wwnd [k*nx+i] = state[ind_w] / ( hy_dens_cell[k+hs] + state[ind_r] );

--- a/c/miniWeather_mpi_openmp45.cpp
+++ b/c/miniWeather_mpi_openmp45.cpp
@@ -284,9 +284,9 @@ void semi_discrete_step( double *state_init , double *state_forcing , double *st
 void compute_tendencies_x( double *state , double *flux , double *tend , double dt ) {
   //int    i,k,ll,s,inds,indf1,indf2,indt;
   //double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
-  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
+  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS]; //, hv_coef;
   //Compute the hyperviscosity coefficient
-  hv_coef = -hv_beta * dx / (16*dt);
+  const double hv_coef = -hv_beta * dx / (16*dt);
   //Compute fluxes in the x-direction for each cell
 #pragma omp target teams distribute parallel for simd collapse(2) private(stencil,vals,d3_vals) depend(inout:asyncid) nowait
   for (int k=0; k<nz; k++) {
@@ -340,9 +340,9 @@ void compute_tendencies_x( double *state , double *flux , double *tend , double 
 void compute_tendencies_z( double *state , double *flux , double *tend , double dt ) {
   //int    i,k,ll,s, inds, indf1, indf2, indt;
   //double r,u,w,t,p, stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
-  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS], hv_coef;
+  double stencil[4], d3_vals[NUM_VARS], vals[NUM_VARS];//, hv_coef;
   //Compute the hyperviscosity coefficient
-  hv_coef = -hv_beta * dz / (16*dt);
+  const double hv_coef = -hv_beta * dz / (16*dt);
   //Compute fluxes in the x-direction for each cell
 #pragma omp target teams distribute parallel for simd collapse(2) private(stencil,vals,d3_vals) depend(inout:asyncid) nowait
   for (int k=0; k<nz+1; k++) {
@@ -496,13 +496,13 @@ void set_halo_values_z( double *state ) {
 void init( int *argc , char ***argv ) {
   //int    i, k, ii, kk, ll, ierr, inds, i_end;
   //double x, z, r, u, w, t, hr, ht, nper;
-  double z, r, u, w, t, hr, ht, nper;
+  //double z, r, u, w, t, hr, ht, nper;
 
   int ierr = MPI_Init(argc,argv);
 
   ierr = MPI_Comm_size(MPI_COMM_WORLD,&nranks);
   ierr = MPI_Comm_rank(MPI_COMM_WORLD,&myrank);
-  nper = ( (double) nx_glob ) / nranks;
+  const double nper = ( (double) nx_glob ) / nranks;
   const int i_beg = round( nper* (myrank)    );
   const int i_end = round( nper*((myrank)+1) )-1;
   nx = i_end - i_beg + 1;
@@ -552,6 +552,8 @@ void init( int *argc , char ***argv ) {
   }
   //Want to make sure this info is displayed before further output
   ierr = MPI_Barrier(MPI_COMM_WORLD);
+
+  double r, u, w, t, hr, ht;
 
   //////////////////////////////////////////////////////////////////////////
   // Initialize the cell-averaged fluid state via Gauss-Legendre quadrature
@@ -612,7 +614,7 @@ void init( int *argc , char ***argv ) {
   }
   //Compute the hydrostatic background state at vertical cell interfaces
   for (int k=0; k<nz+1; k++) {
-    z = (k_beg + k)*dz;
+    const double z = (k_beg + k)*dz;
     if (data_spec_int == DATA_SPEC_COLLISION      ) { collision      (0.,z,r,u,w,t,hr,ht); }
     if (data_spec_int == DATA_SPEC_THERMAL        ) { thermal        (0.,z,r,u,w,t,hr,ht); }
     if (data_spec_int == DATA_SPEC_GRAVITY_WAVES  ) { gravity_waves  (0.,z,r,u,w,t,hr,ht); }
@@ -699,12 +701,12 @@ void collision( double x , double z , double &r , double &u , double &w , double
 void hydro_const_theta( double z , double &r , double &t ) {
   const double theta0 = 300.;  //Background potential temperature
   const double exner0 = 1.;    //Surface-level Exner pressure
-  double       p,exner,rt;
+  //double       p,exner,rt;
   //Establish hydrostatic balance first using Exner pressure
   t = theta0;                                  //Potential Temperature at z
-  exner = exner0 - grav * z / (cp * theta0);   //Exner pressure at z
-  p = p0 * pow(exner,(cp/rd));                 //Pressure at z
-  rt = pow((p / C0),(1. / gamm));             //rho*theta at z
+  const double exner = exner0 - grav * z / (cp * theta0);   //Exner pressure at z
+  const double p = p0 * pow(exner,(cp/rd));                 //Pressure at z
+  const double rt = pow((p / C0),(1. / gamm));             //rho*theta at z
   r = rt / t;                                  //Density at z
 }
 
@@ -716,11 +718,11 @@ void hydro_const_theta( double z , double &r , double &t ) {
 void hydro_const_bvfreq( double z , double bv_freq0 , double &r , double &t ) {
   const double theta0 = 300.;  //Background potential temperature
   const double exner0 = 1.;    //Surface-level Exner pressure
-  double       p, exner, rt;
+  //double       p, exner, rt;
   t = theta0 * exp( bv_freq0*bv_freq0 / grav * z );                                    //Pot temp at z
-  exner = exner0 - grav*grav / (cp * bv_freq0*bv_freq0) * (t - theta0) / (t * theta0); //Exner pressure at z
-  p = p0 * pow(exner,(cp/rd));                                                         //Pressure at z
-  rt = pow((p / C0),(1. / gamm));                                                  //rho*theta at z
+  const double exner = exner0 - grav*grav / (cp * bv_freq0*bv_freq0) * (t - theta0) / (t * theta0); //Exner pressure at z
+  const double p = p0 * pow(exner,(cp/rd));                                                         //Pressure at z
+  const double rt = pow((p / C0),(1. / gamm));                                                  //rho*theta at z
   r = rt / t;                                                                          //Density at z
 }
 
@@ -853,7 +855,6 @@ void ncwrap( int ierr , int line ) {
 
 
 void finalize() {
-  int ierr;
   free( state );
   free( state_tmp );
   free( flux );
@@ -867,7 +868,7 @@ void finalize() {
   free( sendbuf_r );
   free( recvbuf_l );
   free( recvbuf_r );
-  ierr = MPI_Finalize();
+  const int ierr = MPI_Finalize();
 }
 
 
@@ -878,18 +879,18 @@ void reductions( double &mass , double &te ) {
 #pragma omp target teams distribute parallel for simd collapse(2) reduction(+:mass,te)
   for (int k=0; k<nz; k++) {
     for (int i=0; i<nx; i++) {
-      int ind_r = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-      int ind_u = ID_UMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-      int ind_w = ID_WMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-      int ind_t = ID_RHOT*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
-      double r  =   state[ind_r] + hy_dens_cell[hs+k];             // Density
-      double u  =   state[ind_u] / r;                              // U-wind
-      double w  =   state[ind_w] / r;                              // W-wind
-      double th = ( state[ind_t] + hy_dens_theta_cell[hs+k] ) / r; // Potential Temperature (theta)
-      double p  = C0*pow(r*th,gamm);                               // Pressure
-      double t  = th / pow(p0/p,rd/cp);                            // Temperature
-      double ke = r*(u*u+w*w);                                     // Kinetic Energy
-      double ie = r*cv*t;                                          // Internal Energy
+      const int ind_r = ID_DENS*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+      const int ind_u = ID_UMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+      const int ind_w = ID_WMOM*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+      const int ind_t = ID_RHOT*(nz+2*hs)*(nx+2*hs) + (k+hs)*(nx+2*hs) + i+hs;
+      const double r  =   state[ind_r] + hy_dens_cell[hs+k];             // Density
+      const double u  =   state[ind_u] / r;                              // U-wind
+      const double w  =   state[ind_w] / r;                              // W-wind
+      const double th = ( state[ind_t] + hy_dens_theta_cell[hs+k] ) / r; // Potential Temperature (theta)
+      const double p  = C0*pow(r*th,gamm);                               // Pressure
+      const double t  = th / pow(p0/p,rd/cp);                            // Temperature
+      const double ke = r*(u*u+w*w);                                     // Kinetic Energy
+      const double ie = r*cv*t;                                          // Internal Energy
       mass += r        *dx*dz; // Accumulate domain mass
       te   += (ke + ie)*dx*dz; // Accumulate domain total energy
     }


### PR DESCRIPTION
OpenMP data attributes are trivial when declaring at the innermost scope.  This resolves some ambiguities in the OpenMP scope of loop indices and other data objects.